### PR TITLE
Fixed dependency generation for ninja (take II)

### DIFF
--- a/CMake/Compiler/GNU-C.cmake
+++ b/CMake/Compiler/GNU-C.cmake
@@ -1,3 +1,4 @@
 # Copyright (C) 2014-2015 ARM Limited. All rights reserved.
 
 set(CMAKE_C_OUTPUT_EXTENSION ".o")
+set(CMAKE_DEPFILE_FLAGS_C "-MMD -MT <OBJECT> -MF <DEPFILE>")

--- a/CMake/Compiler/GNU-CXX.cmake
+++ b/CMake/Compiler/GNU-CXX.cmake
@@ -1,4 +1,4 @@
 # Copyright (C) 2014-2015 ARM Limited. All rights reserved.
 
 set(CMAKE_CXX_OUTPUT_EXTENSION ".o")
-
+set(CMAKE_DEPFILE_FLAGS_CXX "-MMD -MT <OBJECT> -MF <DEPFILE>")


### PR DESCRIPTION
This is needed for ninja to get its dependencies properly (the proper .d
files are now generated as required by ninja, so changing a header will
trigger a rebuild of the affected source files, as expected).
