### PR TITLE
use config to provide initial size and growth increments for the pool…

### DIFF
--- a/target.json
+++ b/target.json
@@ -21,6 +21,10 @@
     "mbed": {},
     "arch": {
       "arm": {}
+    },
+    "minar" : {
+      "initial_event_pool_size"     : 50,
+      "additional_event_pools_size" : 100
     }
   },
   "toolchain": "CMake/toolchain.cmake"


### PR DESCRIPTION
… of minar::CallbackNodes.

This configuration is necessary to support nRF5x. 
