### PR TITLE
Add support for inline assembly in C files.

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -64,7 +64,7 @@ set(YOTTA_POSTPROCESS_COMMAND "\"${ARM_NONE_EABI_OBJCOPY}\" -O binary YOTTA_CURR
 
 # set default compilation flags
 set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra")
-set(CMAKE_C_FLAGS_INIT   "-std=c99 ${_C_FAMILY_FLAGS_INIT}")
+set(CMAKE_C_FLAGS_INIT   "-std=c99 ${_C_FAMILY_FLAGS_INIT} -fasm")
 set(CMAKE_ASM_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -x assembler-with-cpp")
 set(CMAKE_CXX_FLAGS_INIT "${_C_FAMILY_FLAGS_INIT} -fno-rtti -fno-threadsafe-statics")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT


### PR DESCRIPTION
Add the `-fasm` flag to the C family command line.
Fixes #10 
