### PR TITLE
Add C++11 support to mbed-gcc

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -66,7 +66,7 @@ set(YOTTA_POSTPROCESS_COMMAND "\"${ARM_NONE_EABI_OBJCOPY}\" -O binary YOTTA_CURR
 set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra")
 set(CMAKE_C_FLAGS_INIT   "-std=c99 ${_C_FAMILY_FLAGS_INIT}")
 set(CMAKE_ASM_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -x assembler-with-cpp")
-set(CMAKE_CXX_FLAGS_INIT "${_C_FAMILY_FLAGS_INIT} -fno-rtti -fno-threadsafe-statics")
+set(CMAKE_CXX_FLAGS_INIT "-std=gnu++11 ${_C_FAMILY_FLAGS_INIT} -fno-rtti -fno-threadsafe-statics")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT
     "-fno-exceptions -fno-unwind-tables -Wl,--gc-sections -Wl,--sort-common -Wl,--sort-section=alignment"
 )


### PR DESCRIPTION
`-std=gnu++11` is necessary due to stdio functions.
In `-std=c++11`, several of the va_list variants of printf & scanf, such as vfscanf and vsnprintf, are not found in the gcc standard library.

This PR blocks https://github.com/ARMmbed/core-util/pull/32
