### PR TITLE
<INCLUDES> needs to be explicitly listed here 

### DIFF
--- a/CMake/Platform/mbedOS-GNU-C.cmake
+++ b/CMake/Platform/mbedOS-GNU-C.cmake
@@ -5,7 +5,7 @@
 set(CMAKE_C_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
-set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
 # <LINK_LIBRARIES> is grouped with system libraries so that system library
 # functions (e.g. malloc) can be overridden by symbols in <LINK_LIBRARIES>
 set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lm -lc -lgcc -lm -lc -lgcc -Wl,--end-group  --specs=nano.specs -o <TARGET>")

--- a/CMake/Platform/mbedOS-GNU-C.cmake
+++ b/CMake/Platform/mbedOS-GNU-C.cmake
@@ -1,11 +1,18 @@
 # Copyright (C) 2014-2015 ARM Limited. All rights reserved.
-#message("mbedOS-GNU-C.cmake included")
+
+set(EXPLICIT_INCLUDES "")
+if((CMAKE_VERSION VERSION_GREATER "3.4.0") OR (CMAKE_VERSION VERSION_EQUAL "3.4.0"))
+    # from CMake 3.4 <INCLUDES> are separate to <FLAGS> in the
+    # CMAKE_<LANG>_COMPILE_OBJECT, CMAKE_<LANG>_CREATE_ASSEMBLY_SOURCE, and
+    # CMAKE_<LANG>_CREATE_PREPROCESSED_SOURCE commands
+    set(EXPLICIT_INCLUDES "<INCLUDES> ")
+endif()
 
 # Override the link rules:
 set(CMAKE_C_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_C_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_C_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
-set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_C_COMPILE_OBJECT        "<CMAKE_C_COMPILER> <DEFINES> ${EXPLICIT_INCLUDES}<FLAGS> -o <OBJECT> -c <SOURCE>")
 # <LINK_LIBRARIES> is grouped with system libraries so that system library
 # functions (e.g. malloc) can be overridden by symbols in <LINK_LIBRARIES>
 set(CMAKE_C_LINK_EXECUTABLE       "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lm -lc -lgcc -lm -lc -lgcc -Wl,--end-group  --specs=nano.specs -o <TARGET>")

--- a/CMake/Platform/mbedOS-GNU-CXX.cmake
+++ b/CMake/Platform/mbedOS-GNU-CXX.cmake
@@ -12,10 +12,18 @@ execute_process(
 string(REGEX REPLACE ".* ([0-9]+[.][0-9]+[.][0-9]+) .*" "\\1" _ARM_GNU_GCC_VERSION "${_ARM_GNU_GCC_VERSION_OUTPUT}")
 message("GCC version is: ${_ARM_GNU_GCC_VERSION}")
 
+set(EXPLICIT_INCLUDES "")
+if((CMAKE_VERSION VERSION_GREATER "3.4.0") OR (CMAKE_VERSION VERSION_EQUAL "3.4.0"))
+    # from CMake 3.4 <INCLUDES> are separate to <FLAGS> in the
+    # CMAKE_<LANG>_COMPILE_OBJECT, CMAKE_<LANG>_CREATE_ASSEMBLY_SOURCE, and
+    # CMAKE_<LANG>_CREATE_PREPROCESSED_SOURCE commands
+    set(EXPLICIT_INCLUDES "<INCLUDES> ")
+endif()
+
 set(CMAKE_CXX_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_CXX_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
-set(CMAKE_CXX_COMPILE_OBJECT        "<CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_CXX_COMPILE_OBJECT        "<CMAKE_CXX_COMPILER> <DEFINES> ${EXPLICIT_INCLUDES}<FLAGS> -o <OBJECT> -c <SOURCE>")
 # <LINK_LIBRARIES> is grouped with system libraries so that system library
 # functions (e.g. malloc) can be overridden by symbols in <LINK_LIBRARIES>
 set(CMAKE_CXX_LINK_EXECUTABLE       "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lstdc++ -lsupc++ -lm -lc -lgcc -lstdc++ -lsupc++ -lm -lc -lgcc -Wl,--end-group  --specs=nano.specs -o <TARGET>")

--- a/CMake/Platform/mbedOS-GNU-CXX.cmake
+++ b/CMake/Platform/mbedOS-GNU-CXX.cmake
@@ -15,7 +15,7 @@ message("GCC version is: ${_ARM_GNU_GCC_VERSION}")
 set(CMAKE_CXX_CREATE_SHARED_LIBRARY "echo 'shared libraries not supported' && 1")
 set(CMAKE_CXX_CREATE_SHARED_MODULE  "echo 'shared modules not supported' && 1")
 set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> -cr <LINK_FLAGS> <TARGET> <OBJECTS>")
-set(CMAKE_CXX_COMPILE_OBJECT        "<CMAKE_CXX_COMPILER> <DEFINES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_CXX_COMPILE_OBJECT        "<CMAKE_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
 # <LINK_LIBRARIES> is grouped with system libraries so that system library
 # functions (e.g. malloc) can be overridden by symbols in <LINK_LIBRARIES>
 set(CMAKE_CXX_LINK_EXECUTABLE       "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -Wl,-Map,<TARGET>.map -Wl,--start-group <OBJECTS> <LINK_LIBRARIES> ${GLOBALLY_LINKED_TARGET_LIBS} -lstdc++ -lsupc++ -lm -lc -lgcc -lstdc++ -lsupc++ -lm -lc -lgcc -Wl,--end-group  --specs=nano.specs -o <TARGET>")


### PR DESCRIPTION
(for some reason everything worked OK without this with older CMake versions)

Need to verify how backwards compatible this is with old CMake versions before merging.
