### PR TITLE
Add a default baud rate at 9600

### DIFF
--- a/target.json
+++ b/target.json
@@ -19,6 +19,11 @@
   ],
   "config": {
     "mbed": {},
+    "mbed-os" : {
+        "stdio" : {
+            "default-baud" : 9600
+        }
+    },
     "arch": {
       "arm": {}
     },


### PR DESCRIPTION
This will stop https://github.com/ARMmbed/mbed-drivers/pull/128 from breaking test jobs until mbedgt can extract the default baud from yotta config.

cc @bogdanm @PrzemekWirkus 
