### PR TITLE
Add single-module code-coverage support

### DIFF
--- a/coverage/coverage.cmake
+++ b/coverage/coverage.cmake
@@ -1,0 +1,12 @@
+
+string(TOUPPER "${YOTTA_MODULE_NAME}" upper_name)
+string(REPLACE "-" "_" under_name "${upper_name}")
+
+if(${YOTTA_CFG_DEBUG_OPTIONS_COVERAGE_MODULES_${under_name}})
+    message("Code coverage enabled on ${YOTTA_MODULE_NAME}")
+    get_property(s TARGET ${YOTTA_MODULE_NAME} PROPERTY COMPILE_FLAGS SET)
+    if(${s})
+        get_target_property(flags ${YOTTA_MODULE_NAME} COMPILE_FLAGS)
+    endif()
+    set_target_properties(${YOTTA_MODULE_NAME} PROPERTIES COMPILE_FLAGS "${flags} -fprofile-arcs -ftest-coverage")
+endif()

--- a/target.json
+++ b/target.json
@@ -32,5 +32,6 @@
       "additional_event_pools_size": 100
     }
   },
-  "toolchain": "CMake/toolchain.cmake"
+  "toolchain": "CMake/toolchain.cmake",
+  "cmakeIncludes": ["coverage/coverage.cmake"]
 }


### PR DESCRIPTION
Use the support from https://github.com/ARMmbed/yotta/pull/633 to enable cmakeIncludes
Add a cmakeInclude include to enable coverage if configured by yotta config

For example, to enable code coverage on sockets, use:

``` JSON
    "debug" : {
        "options" : {
            "coverage" : {
                "modules" : {
                    "sockets" : true
                }
            }
        }
    }
```
