### PR TITLE
Turn off DWARF vnext extensions to avoid tripping up IDEs

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -61,7 +61,7 @@ set(YOTTA_POSTPROCESS_COMMAND "\"${ARM_NONE_EABI_OBJCOPY}\" -O binary YOTTA_CURR
 
 
 # set default compilation flags
-set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra")
+set(_C_FAMILY_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -ffunction-sections -fdata-sections -Wall -Wextra -gstrict-dwarf")
 set(CMAKE_C_FLAGS_INIT   "-std=c99 ${_C_FAMILY_FLAGS_INIT}")
 set(CMAKE_ASM_FLAGS_INIT "-fno-exceptions -fno-unwind-tables -x assembler-with-cpp")
 set(CMAKE_CXX_FLAGS_INIT "--std=gnu++11 ${_C_FAMILY_FLAGS_INIT} -fno-rtti -fno-threadsafe-statics")


### PR DESCRIPTION
Verified with Keil uVsion v5.16a. By default, the GCC compiler generates DWARF v4 output, but uses some extensions from v5 and/or beyond if not explicitly told not to do so. uVision can't currently handle those extensions, so if you try to debug a GCC-built program, it will crash. Telling GCC to not use those extensions fixes the crash.

Probably there are more IDEs out there with the same problem.
